### PR TITLE
Fix so directory module permissions can be overridden via config

### DIFF
--- a/protected/humhub/modules/directory/controllers/DirectoryController.php
+++ b/protected/humhub/modules/directory/controllers/DirectoryController.php
@@ -183,4 +183,11 @@ class DirectoryController extends Controller
         return $this->render('userPosts', []);
     }
 
+    public function getAccessRules()
+    {
+        return [
+            ['permissions' => \humhub\modules\directory\permissions\AccessDirectory::class]
+        ];
+    }
+
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch if no hotfix
- [x] When resolving a specific issue, it's referenced in the PR's description (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the Github issue number)
- [?] All tests are passing
- [?] New/updated tests are included
- [?] Changelog was modified

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Adding the param "defaultPermissions" via config as described in http://docs.humhub.org/admin-permissions.html did not work for the directory module. 
This would enable an Admin to e.g. block this module for guests via configuration.
It had simply no effect. The permission class wasn't even included. 
Adding the getAccessRules method, as other modules have it, solves this issue.